### PR TITLE
Link to "custom" version was broken

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -34,7 +34,7 @@ services:
 *   **[7](https://hub.docker.com/r/_/solr/)** **(default)**
 *   [7.7](https://hub.docker.com/r/_/solr/)
 *   [7.6](https://hub.docker.com/r/_/solr/)
-*   [custom](https://doc.lando.dev/config/services.html#advanced)
+*   [custom](https://doc.lando.dev/config/services.html#custom-installation)
 
 ## Legacy versions
 


### PR DESCRIPTION
Changed to the only ID that made sense.