### PR TITLE
feat: update @lando/php to ^1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated to [@lando/php@1.12.0](https://github.com/lando/php/releases/tag/v1.12.0) for mod_headers/mod_expires and xdebug log fix
+
 ## v1.5.0 - [February 18, 2026](https://github.com/lando/solr/releases/tag/v1.5.0)
 
 * Updated `@lando/php` to `^1.10.0`

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,33 +1,32 @@
 ---
 title: Solr Lando Plugin
 description: Add a highly configurable Apache Solr service to Lando for local development with all the power of Docker and Docker Compose.
+next: ./config.html
 ---
 
 # Solr
 
 [Solr](https://solr.apache.org/) is highly reliable, scalable and fault tolerant, providing distributed indexing, replication and load-balanced querying, automated failover and recovery, centralized configuration and more. Solr powers the search and navigation features of many of the world's largest internet sites.
 
-You can easily add it to your Lando app by adding an entry to the [services](https://docs.lando.dev/services/lando-3.html) top-level config in your [Landofile](https://docs.lando.dev/landofile/).
+You can easily add it to your Lando app by adding an entry to the [services](https://docs.lando.dev/services/lando-3.html) top-level config in your [Landofile](https://docs.lando.dev/core/v3).
 
 ```yaml
 services:
   myservice:
-    type: solr:9
+    type: solr
 ```
 
 ## Supported versions
 
-*   [9.9](https://hub.docker.com/_/solr/)
-*   [9.8](https://hub.docker.com/_/solr/)
-*   [9.7](https://hub.docker.com/_/solr/)
-*   [9.6](https://hub.docker.com/_/solr/)
-*   [9.5](https://hub.docker.com/_/solr/)
-*   [9.4](https://hub.docker.com/_/solr/)
-*   [9.3](https://hub.docker.com/_/solr/)
-*   [9.2](https://hub.docker.com/_/solr/)
-*   [9.1](https://hub.docker.com/_/solr/)
-*   [9](https://hub.docker.com/_/solr/)
-*   [9.0](https://hub.docker.com/_/solr/)
+*   [9.7](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9.6](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9.5](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9.4](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9.3](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9.2](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9.1](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9](https://hub.docker.com/_/solr/) **(experimental)**
+*   [9.0](https://hub.docker.com/_/solr/) **(experimental)**
 *   [8](https://hub.docker.com/_/solr/)
 *   [8.11](https://hub.docker.com/_/solr/)
 *   [8.10](https://hub.docker.com/_/solr/)
@@ -41,7 +40,7 @@ services:
 *   [8.2](https://hub.docker.com/_/solr/)
 *   [8.1](https://hub.docker.com/_/solr/)
 *   [8.0](https://hub.docker.com/_/solr/)
-*   [7](https://hub.docker.com/_/solr/)
+*   **[7](https://hub.docker.com/_/solr/)** **(default)**
 *   [7.7](https://hub.docker.com/_/solr/)
 *   [7.6](https://hub.docker.com/_/solr/)
 *   [custom](https://docs.lando.dev/services/lando-3.html#overrides)

--- a/netlify.toml
+++ b/netlify.toml
@@ -10,7 +10,7 @@
 [[context.deploy-preview.plugins]]
   package = "netlify-plugin-checklinks"
   [context.deploy-preview.plugins.inputs]
-    todoPatterns = [ "load", "CHANGELOG.html", "x.com", "twitter.com", "/v/", "https://hub.docker.com/_/solr/", "https://hub.docker.com/r/actency/docker-solr" ]
+    todoPatterns = [ "load", "CHANGELOG.html", "x.com", "twitter.com", "/v/", "docs.lando.dev/core/v3", "https://hub.docker.com/_/solr/", "https://hub.docker.com/r/actency/docker-solr" ]
     skipPatterns = [ ".rss", ".gif", ".jpg" ]
     checkExternal = true
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       "devDependencies": {
         "@babel/eslint-parser": "^7.16.0",
         "@lando/leia": "^0.6.5",
-        "@lando/php": "^1.10.0",
+        "@lando/php": "^1.12.0",
         "@lando/vitepress-theme-default-plus": "^1.1.5",
         "chai": "^4.3.4",
         "command-line-test": "^1.0.10",
@@ -1539,9 +1539,9 @@
       }
     },
     "node_modules/@lando/php": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.2.tgz",
-      "integrity": "sha512-1fsT+GPThmUkB8X5iprBkX+VBoor/sXB8/oOwGFabeeVCcVq6ymDSBWgs8Qf2hdoxJiJcNT871//ohkQaotLYw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.12.0.tgz",
+      "integrity": "sha512-yHhjdtGv0zgylfOubbWz09ufTr8yfi7so262RDJT5P03T24LfHPOBLFLTtdI8I1k0kzH9phxhQ4aZyex9TMhsg==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   "devDependencies": {
     "@babel/eslint-parser": "^7.16.0",
     "@lando/leia": "^0.6.5",
-    "@lando/php": "^1.10.0",
+    "@lando/php": "^1.12.0",
     "@lando/vitepress-theme-default-plus": "^1.1.5",
     "chai": "^4.3.4",
     "command-line-test": "^1.0.10",


### PR DESCRIPTION
## Changes

- Updated `@lando/php` to `^1.12.0`

## What's in @lando/php v1.12.0

- Enabled mod_headers and mod_expires Apache modules by default ([php#244](https://github.com/lando/php/pull/244))
- Fixed xdebug log file ownership issue when build_as_root or run_as_root creates /tmp/xdebug.log as root ([php#242](https://github.com/lando/php/pull/242))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily a dev dependency bump plus documentation and Netlify link-checklist tweaks, with no changes to core plugin/runtime logic.
> 
> **Overview**
> Updates `@lando/php` to `^1.12.0` (and regenerates `package-lock.json`), with a changelog entry calling out the Apache module enablement and xdebug log ownership fix.
> 
> Refreshes docs to use `type: solr` in the quickstart, marks Solr 9.x entries as **experimental**, and calls out Solr 7 as the **default**; also tweaks VitePress frontmatter and Netlify checklinks `todoPatterns` to account for updated `docs.lando.dev/core/v3` links.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1b73a409b69b6d22e1a7b25e0f2d26951ac92a7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->